### PR TITLE
manage service

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: '1.4.2'
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.2.0'
     zypprepo:
       repo: 'git://github.com/deadpoint/puppet-zypprepo.git'
   symlinks:

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,8 @@ doc/
 # Puppet
 coverage/
 spec/fixtures/modules/*
-spec/fixtures
+spec/fixtures/manifests/*
+Gemfile.lock
+
+# Geppetto
+.project

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Base URL of mirror of packages.vmware.com/tools/esx.
 
 - *Default*: http://packages.vmware.com/tools/esx
 
+manage_service
+--------------
+If vmwaretools service should be managed (boolean)
+
+- *Default*: true
+
+service_name
+------------
+Service name to manage (string).
+
+- *Default*: 'USE_DEFAULTS', based on OS platform
+
 esx_version
 -----------
 Version of ESX (e.g. 5.1, 5.5, 5.5ep06) ... note, it is recommended to explicitly set the esx version rather than default to latest.

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -31,6 +31,12 @@ describe 'vmware' do
            'proxy' => 'undef',
          })
       }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure'  => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
+      }
     end
 
     context 'on machine with X installed' do
@@ -70,6 +76,12 @@ describe 'vmware' do
       }
       it {
         should_not contain_yumrepo('vmware-osps')
+      }
+      it {
+        should contain_service('vmtoolsd').with({
+           'ensure'  => 'running',
+           'require' => 'Package[open-vm-tools]',
+        })
       }
     end
 
@@ -120,6 +132,12 @@ describe 'vmware' do
            'gpgcheck' => '1',
            'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
          })
+      }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure'  => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
       }
     end
 
@@ -172,6 +190,12 @@ describe 'vmware' do
            'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
          })
       }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure' => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
+      }
     end
 
     context 'on machine with X installed' do
@@ -213,6 +237,11 @@ describe 'vmware' do
       it {
         should_not contain_zypprepo('vmware-osps')
       }
+      it {
+        should contain_service('vmtoolsd').with({
+           'ensure' => 'running',
+        })
+      }
     end
 
     context 'on machine with X installed' do
@@ -252,6 +281,13 @@ describe 'vmware' do
       }
       it {
         should_not contain_class('apt')
+      }
+      it {
+        should contain_service('open-vm-tools').with({
+           'ensure'    => 'running',
+           'hasstatus' => 'false',
+           'status'    => '/bin/ps -ef | /bin/grep -i "vmtoolsd" | /bin/grep -v "grep"',
+        })
       }
     end
 
@@ -300,6 +336,12 @@ describe 'vmware' do
             'repos'       => 'main',
             'include_src' => false,
          })
+      }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure'  => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
       }
     end
 
@@ -359,6 +401,12 @@ describe 'vmware' do
     it { should_not contain_package('vmware-tools-esx') }
     it { should_not contain_package('vmware-tools-esx-nox') }
     it { should_not contain_exec('Remove vmware tools script installation') }
+    it {
+      should contain_service('vmware-tools-services').with({
+         'ensure'  => 'running',
+         'require' => 'Package[vmware-tools-esx-nox]',
+      })
+    }
   end
 
   context 'on a machine that does not run on vmware' do
@@ -372,6 +420,7 @@ describe 'vmware' do
     it { should_not contain_package('vmware-tools-esx') }
     it { should_not contain_package('vmware-tools-esx-nox') }
     it { should_not contain_exec('Remove vmware tools script installation') }
+    it { should_not contain_service('vmware-tools-services') }
   end
 
   describe 'with incorrect types' do
@@ -393,6 +442,19 @@ describe 'vmware' do
         expect {
           should contain_class('vmware')
         }.to raise_error(Puppet::Error,/\["no"\] is not a boolean.  It looks to be a Array/)
+      end
+    end
+
+    context 'with manage_service as an array' do
+      let(:params) do
+        { :manage_service => ['no'],
+        }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('vmware')
+        }.to raise_error(Puppet::Error,/str2bool\(\): Requires either string to work with /)
       end
     end
 


### PR DESCRIPTION
This patch fixes the problem that the service was not automatically started on RH7 while installation.
I have positivly tested it with: RedHat 5/6/7, SLES 10/11 & Ubuntu 12/14.

If you don't like to upgrade to stdlib 4.2, is_bool can be changed to is_string.