### PR TITLE
Fix OpenSuSE tools_x_package_name_default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,8 +80,12 @@ class vmware (
           $_tools_x_package_name_default = 'open-vm-tools-desktop'
           $_service_name_default         = 'vmtoolsd'
         }
-        'SLED', 'SLES', 'OpenSuSE': {
+        'SLED', 'SLES': {
           $_tools_x_package_name_default = 'open-vm-tools-desktop'
+          $_service_name_default         = 'vmtoolsd'
+        }
+        'OpenSuSE': {
+          $_tools_x_package_name_default = 'open-vm-tools-gui'
           $_service_name_default         = 'vmtoolsd'
         }
         'Ubuntu': {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -434,7 +434,7 @@ describe 'vmware' do
         }
       end
 
-      it { should contain_package('open-vm-tools-desktop').with('ensure' => 'present') }
+      it { should contain_package('open-vm-tools-gui').with('ensure' => 'present') }
     end
   end
 


### PR DESCRIPTION
OpenSuSE uses open-vm-tools-gui rather than open-vm-tools-desktop on SLES.
